### PR TITLE
Use SESSION_SECRET env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Put these variables into `.dev.vars`
 ```
 CALLS_APP_ID=<APP_ID_GOES_HERE>
 CALLS_APP_SECRET=<SECRET_GOES_HERE>
+SESSION_SECRET=<SECRET_GOES_HERE>
 ```
 
 ### Optional variables
@@ -54,16 +55,18 @@ wrangler login
 
 2. Update `CALLS_APP_ID` in `wrangler.toml` to use your own Calls App ID
 
-3. You will also need to set the token as a secret by running:
+3. You will also need to set the tokens as secrets by running:
 
 ```sh
 wrangler secret put CALLS_APP_SECRET
+wrangler secret put SESSION_SECRET
 ```
 
-or to programmatically set the secret, run:
+or to programmatically set the secrets, run:
 
 ```sh
 echo REPLACE_WITH_YOUR_SECRET | wrangler secret put CALLS_APP_SECRET
+echo REPLACE_WITH_YOUR_SESSION_SECRET | wrangler secret put SESSION_SECRET
 ```
 
 4. Optionally, you can also use [Cloudflare's TURN Service](https://developers.cloudflare.com/calls/turn/) by setting the `TURN_SERVICE_ID` variable in `wrangler.toml` and `TURN_SERVICE_TOKEN` secret using `wrangler secret put TURN_SERVICE_TOKEN`

--- a/app/session.ts
+++ b/app/session.ts
@@ -1,11 +1,15 @@
 import { createCookieSessionStorage } from '@remix-run/cloudflare'
+import invariant from 'tiny-invariant'
+
+const SESSION_SECRET = process.env.SESSION_SECRET
+invariant(SESSION_SECRET, 'SESSION_SECRET must be set')
 
 export const { getSession, commitSession, destroySession } =
 	createCookieSessionStorage({
 		// a Cookie from `createCookie` or the same CookieOptions to create one
 		cookie: {
 			name: '__session',
-			secrets: ['oooOOooOOoOOoOOOOoo'],
+                       secrets: [SESSION_SECRET],
 			sameSite: true,
 			httpOnly: true,
 		},

--- a/app/types/Env.ts
+++ b/app/types/Env.ts
@@ -1,8 +1,9 @@
 export type Env = {
-	rooms: DurableObjectNamespace
-	CALLS_APP_ID: string
-	CALLS_APP_SECRET: string
-	CALLS_API_URL?: string
+        rooms: DurableObjectNamespace
+        CALLS_APP_ID: string
+        CALLS_APP_SECRET: string
+        SESSION_SECRET: string
+        CALLS_API_URL?: string
 	E2EE_ENABLED?: string
 	USER_DIRECTORY_URL?: string
 	FEEDBACK_URL?: string

--- a/wrangler.development.toml
+++ b/wrangler.development.toml
@@ -59,5 +59,6 @@ enabled = true
 
 # The necessary secrets are:
 # - CALLS_APP_SECRET
+# - SESSION_SECRET
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
 

--- a/wrangler.e2ee.toml
+++ b/wrangler.e2ee.toml
@@ -36,6 +36,7 @@ deleted_classes = ["RateLimiter"]
 
 # The necessary secrets are:
 # - CALLS_APP_SECRET
+# - SESSION_SECRET
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
 
 

--- a/wrangler.production.toml
+++ b/wrangler.production.toml
@@ -59,6 +59,7 @@ enabled = true
 
 # The necessary secrets are:
 # - CALLS_APP_SECRET
+# - SESSION_SECRET
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
 
 

--- a/wrangler.public.toml
+++ b/wrangler.public.toml
@@ -35,6 +35,7 @@ deleted_classes = ["RateLimiter"]
 
 # The necessary secrets are:
 # - CALLS_APP_SECRET
+# - SESSION_SECRET
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
 
 

--- a/wrangler.staging.toml
+++ b/wrangler.staging.toml
@@ -59,6 +59,7 @@ enabled = true
 
 # The necessary secrets are:
 # - CALLS_APP_SECRET
+# - SESSION_SECRET
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
 
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,6 +26,7 @@ new_classes = ["ChatRoom"]
 
 # The necessary secrets are:
 # - CALLS_APP_SECRET
+# - SESSION_SECRET
 # To add secret, run `echo <VALUE> | wrangler secret put <NAME>`
 
 # Optional secrets:


### PR DESCRIPTION
## Summary
- load cookie secrets from the `SESSION_SECRET` environment variable
- type `SESSION_SECRET` on `Env`
- document the new secret in README
- mention the new secret in wrangler configs

## Testing
- `npm run check` *(fails: Cannot find package 'prettier-plugin-organize-imports')*