### PR TITLE
Refactor tests for node:test

### DIFF
--- a/app/hooks/useStageManager.test.ts
+++ b/app/hooks/useStageManager.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
 import { resolveRoster } from './useStageManager'
 
 const a = { id: 'a' }
@@ -10,34 +11,34 @@ describe('resolveRoster', () => {
 	it('should return the stable list in the same order even if roster is out of order', () => {
 		const stableList = [a, b, c, d]
 		const result = resolveRoster(stableList, [b, c, a, d])
-		expect(result).toEqual(stableList)
+                assert.deepStrictEqual(result, stableList)
 	})
 
 	it('should replace items in the stable list with items in the roster not present in the stable list', () => {
 		const stableList = [a, b, c]
 		const result = resolveRoster(stableList, [c, a, d])
-		expect(result).toEqual([a, d, c])
+                assert.deepStrictEqual(result, [a, d, c])
 	})
 
 	it(`should append items in the roster that aren't in the stable list`, () => {
 		const stableList = [a, c]
 		const roster = [a, b, c, d]
 		const result = resolveRoster(stableList, roster)
-		expect(result).toEqual([a, c, b, d])
+                assert.deepStrictEqual(result, [a, c, b, d])
 	})
 
 	it(`should drop items in the stable list that aren't in the roster`, () => {
 		const stableList = [a, b, c, d]
 		const roster = [a, b, c]
 		const result = resolveRoster(stableList, roster)
-		expect(result).toEqual(roster)
+                assert.deepStrictEqual(result, roster)
 	})
 
 	it(`should populate a list if the current roster is empty`, () => {
 		const stableList = [] as { id: string }[]
 		const roster = [a, b, c]
 		const result = resolveRoster(stableList, roster)
-		expect(result).toEqual(roster)
+                assert.deepStrictEqual(result, roster)
 	})
 
 	it(`should populate the list with items from the new roster array`, () => {
@@ -47,6 +48,6 @@ describe('resolveRoster', () => {
 			stableList,
 			roster
 		)
-		expect(result[2].foo).toBeTruthy()
+                assert.ok(result[2].foo)
 	})
 })

--- a/app/root.test.ts
+++ b/app/root.test.ts
@@ -1,10 +1,11 @@
 import { Crypto } from '@peculiar/webcrypto'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
 import { loader } from './root'
 import { commitSession, getSession } from './session'
 import { ACCESS_AUTHENTICATED_USER_EMAIL_HEADER } from './utils/constants'
 
-vi.stubGlobal('crypto', new Crypto())
+globalThis.crypto = new Crypto()
 
 const CF_AppSession = 'oaiwjefoaijwefoij'
 
@@ -55,14 +56,15 @@ describe('root loader', () => {
 		} catch (e) {
 			if (!(e instanceof Response)) throw e
 			var response = e
-			expect(response.status).toBe(302)
-			expect(response.headers.get('Location')).toBe(url.toString())
-			expect(response.headers.get('Set-Cookie')).toBe(
-				[
-					'CF_Authorization=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;',
-					'CF_AppSession=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;',
-				].join(', ')
-			)
+                        assert.strictEqual(response.status, 302)
+                        assert.strictEqual(response.headers.get('Location'), url.toString())
+                        assert.strictEqual(
+                                response.headers.get('Set-Cookie'),
+                                [
+                                        'CF_Authorization=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;',
+                                        'CF_AppSession=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;',
+                                ].join(', ')
+                        )
 		}
 	})
 
@@ -93,7 +95,7 @@ describe('root loader', () => {
 			params: {},
 		})
 
-		expect(response?.status).not.equals(302)
+                assert.notStrictEqual(response?.status, 302)
 	})
 
 	it('should return null if CF_Authorization Cookie will expire in 25 hours', async () => {
@@ -122,7 +124,7 @@ describe('root loader', () => {
 			params: {},
 		})
 
-		expect(response?.status).not.equals(302)
+                assert.notStrictEqual(response?.status, 302)
 	})
 
 	it('should redirect to /set-username if CF_Authorization Cookie is missing', async () => {
@@ -134,12 +136,12 @@ describe('root loader', () => {
 				context: { env: {} } as any,
 				params: {},
 			})
-			expect(response.status).not.equals(302)
+                        assert.notStrictEqual(response.status, 302)
 		} catch (r) {
 			if (!(r instanceof Response)) throw r
 			redirect = r
 		}
-		expect(redirect?.status).toBe(302)
+                assert.strictEqual(redirect?.status, 302)
 	})
 
 	it('should NOT redirect to /set-username if CF_Authorization Cookie is missing but username is set', async () => {
@@ -159,11 +161,11 @@ describe('root loader', () => {
 				context: { env: {} } as any,
 				params: {},
 			})
-			expect(response.status).not.equals(302)
+                        assert.notStrictEqual(response.status, 302)
 		} catch (r) {
 			if (!(r instanceof Response)) throw r
 			redirect = r
 		}
-		expect(redirect?.status).not.equals(302)
+                assert.notStrictEqual(redirect?.status, 302)
 	})
 })

--- a/app/utils/Peer.test.ts
+++ b/app/utils/Peer.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-loop-func */
-import { expect, test } from 'vitest'
+import test from 'node:test'
+import assert from 'node:assert/strict'
 import { BulkRequestDispatcher, FIFOScheduler } from './Peer.utils'
 
 test('schedule', async () => {
@@ -15,7 +16,7 @@ test('schedule', async () => {
 	await scheduler.schedule(async () => {
 		list.push(3)
 	})
-	expect(list).toStrictEqual([1, 2, 3])
+        assert.deepStrictEqual(list, [1, 2, 3])
 })
 
 test('taskError', async () => {
@@ -32,9 +33,9 @@ test('taskError', async () => {
 	try {
 		await p1
 	} catch (error: any) {
-		expect(error.message).eq(err1)
+                assert.strictEqual(error.message, err1)
 	}
-	expect(await p2).eq(ok)
+        assert.strictEqual(await p2, ok)
 })
 
 test('bulkRequest', async () => {
@@ -44,14 +45,14 @@ test('bulkRequest', async () => {
 	let requestSent = false
 	for (let i = 0; i < 4; i++) {
 		dispatcher.doBulkRequest(i, async (bulkCopy: number[]) => {
-			expect(bulkCopy).toStrictEqual([0, 1, 2, 3])
+                        assert.deepStrictEqual(bulkCopy, [0, 1, 2, 3])
 			requestSent = true
 		})
 	}
-	expect(requestSent).eq(false)
+        assert.strictEqual(requestSent, false)
 	// just waits for a macrotask after the bulk request
 	await new Promise((r) => setTimeout(r, 100))
-	expect(requestSent).eq(true)
+        assert.strictEqual(requestSent, true)
 })
 
 test('bulkRequestWithLimit', async () => {
@@ -61,20 +62,20 @@ test('bulkRequestWithLimit', async () => {
 	let requests = 0
 	for (let i = 0; i < 2; i++) {
 		dispatcher.doBulkRequest(i, async (bulkCopy: number[]) => {
-			expect(bulkCopy).toStrictEqual([0, 1])
+                        assert.deepStrictEqual(bulkCopy, [0, 1])
 			requests++
 		})
 	}
 	for (let i = 2; i < 4; i++) {
 		dispatcher.doBulkRequest(i, async (bulkCopy: number[]) => {
-			expect(bulkCopy).toStrictEqual([2, 3])
+                        assert.deepStrictEqual(bulkCopy, [2, 3])
 			requests++
 		})
 	}
-	expect(requests).eq(0)
+        assert.strictEqual(requests, 0)
 	// just waits for a macrotask after the bulk request
 	await new Promise((r) => setTimeout(r, 100))
-	expect(requests).eq(2)
+        assert.strictEqual(requests, 2)
 })
 
 test('bulkRequestBatchCopy', async () => {
@@ -88,19 +89,19 @@ test('bulkRequestBatchCopy', async () => {
 			// third enqueued macrotask: we delay the request execution to run first
 			// doBulkRequest(42, ..)
 			setTimeout(() => {
-				expect(bulkCopy).toStrictEqual([0, 1])
+                                assert.deepStrictEqual(bulkCopy, [0, 1])
 				requestSent = true
 			}, 0)
 		})
 	}
-	expect(requestSent).eq(false)
+        assert.strictEqual(requestSent, false)
 	// second enqueued macrotask
 	setTimeout(() => {
-		expect(requestSent).eq(false)
+                assert.strictEqual(requestSent, false)
 		// this is the ultimate test: bulkCopy of the first request shoudn't include 42
 		dispatcher.doBulkRequest(42, async (_bulkCopy: number[]) => {})
 	}, 0)
 	// wait for the completion
 	await new Promise((r) => setTimeout(r, 100))
-	expect(requestSent).eq(true)
+        assert.strictEqual(requestSent, true)
 })


### PR DESCRIPTION
## Summary
- switch vitest test files in `app/` to use `node:test`
- convert all `expect` calls to Node's `assert`
- remove `vi.stubGlobal` usage and set globals manually
- verify `node --test` runs (fails due to unknown TS extension)

## Testing
- `node --test app/hooks/useStageManager.test.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `node --test app/root.test.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `node --test app/utils/Peer.test.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*