### PR TITLE
Fix root test to use node webcrypto

### DIFF
--- a/app/root.test.ts
+++ b/app/root.test.ts
@@ -1,11 +1,11 @@
-import { Crypto } from '@peculiar/webcrypto'
+import { webcrypto } from 'node:crypto'
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { loader } from './root'
 import { commitSession, getSession } from './session'
 import { ACCESS_AUTHENTICATED_USER_EMAIL_HEADER } from './utils/constants'
 
-globalThis.crypto = new Crypto()
+globalThis.crypto = webcrypto
 
 const CF_AppSession = 'oaiwjefoaijwefoij'
 


### PR DESCRIPTION
## Summary
- update `app/root.test.ts` to use Node's built-in `webcrypto`

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: EHOSTUNREACH)*