### PR TITLE
Add tsconfig.test.json and update test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ npm run dev
 
 Open up [http://127.0.0.1:8787](http://127.0.0.1:8787) and you should be ready to go!
 
+## Testing
+
+Compile the TypeScript tests and run them with Node's built-in test runner:
+
+```sh
+npm test
+```
+
+This command builds the tests into `dist-tests` using `tsc -p tsconfig.test.json`
+and then executes them via `node --test`.
+
 ## Deployment
 
 1. Make sure you've installed `wrangler` and are logged in by running:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"prettier": "prettier -w .",
 		"typecheck": "tsc --noEmit --skipLibCheck",
 		"typecheck:watch": "npm run typecheck -- --watch",
-		"test": "vitest",
+                "test": "tsc -p tsconfig.test.json && node --test dist-tests",
 		"test:ci": "vitest --watch false",
 		"test:e2e": "playwright test --headed",
 		"check": "npm run lint && npm run typecheck && npm run test:ci",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "outDir": "dist-tests"
+    }
+}


### PR DESCRIPTION
## Summary
- compile tests with new tsconfig.test.json
- output compiled tests to `dist-tests`
- use Node's built-in test runner via `npm test`
- document test workflow

## Testing
- `npm test` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*